### PR TITLE
Fix pie charts legend not showing the correct value

### DIFF
--- a/frontend/src/summary/graphs/PieChart.jsx
+++ b/frontend/src/summary/graphs/PieChart.jsx
@@ -5,14 +5,20 @@ import DiscreteColorLegend from 'react-vis/dist/legends/discrete-color-legend';
 
 const PieChart = ({values}) => {
     const [isValid, setIsValid] = useState(null);
+    const [total, setTotal] = useState(0);
 
     useEffect(() => {
         if (values){
+            var totalValue = 0;
             var noOfValues = 0;
             values.forEach((val) => {
                 if (val.angle != 0)
+                {
                     noOfValues = noOfValues + 1;
+                    totalValue += Number(val.angle);
+                }
             });
+            setTotal(totalValue);
             setIsValid(noOfValues !== 0);
         }
     }, [values]);
@@ -29,7 +35,7 @@ const PieChart = ({values}) => {
                 <RadialChart
                     width={500}
                     height={350}
-                    data={values}
+                    data={values.filter(v => v.angle != 0)}
                     colorType="literal"
                     />
                 <DiscreteColorLegend
@@ -37,7 +43,7 @@ const PieChart = ({values}) => {
                     width={300}
                     items={
                         values.filter(v => v.angle != 0)
-                            .map((val) => {return {title: val.label + " (" + Number(val.angle).toFixed(2) + "%)", color: val.color, stroke: '#fff', strokeWidth: '10'}})
+                            .map((val) => {return {title: val.label + " (" + Number(100 * val.angle / (total == 0? 1 : total)).toFixed(2) + "%)", color: val.color, stroke: '#fff', strokeWidth: '10'}})
                         }
                     />
                 </div>


### PR DESCRIPTION

### Explication

- Corrigé le pourcentage dans la légende des pie charts.
- Les catégories dont l'angle sur le pie chart est 0 ne sont plus affichés (une ligne était visible).

### Checklist 
- [ ] Cette PR modifie la DB 
- [x] J'ai testé mes changements

### À tester

- Summary affiche correctement le pourcentage dans la légende des pie charts

### Screenshot

*Si on a un changement au frontend*
