### PR TITLE
Add confirmation before deletion

### DIFF
--- a/frontend/src/categories/Categories.jsx
+++ b/frontend/src/categories/Categories.jsx
@@ -150,7 +150,9 @@ const Categories = () => {
 
         return [
             {
-                title: <EditMenu onEditClick={() => {onEditCategory(category)}} onDeleteClick={() => {onDeleteCategory(category)}}/>,
+                title: <EditMenu onEditClick={() => {onEditCategory(category)}} 
+                    onDeleteClick={() => {onDeleteCategory(category)}} 
+                    onDeleteMessage="Voulez-vous vraiment supprimer la catégorie?"/>,
                 width: 50,
                 render: () => ""
             },
@@ -159,7 +161,9 @@ const Categories = () => {
                 align: 'left',
                 colSpan: 2,
                 width: 50,
-                render: (line) =>(<EditMenu onEditClick={() => {onEditLine(category.id, line)}} onDeleteClick={() => {onDeleteLine(line)}}/> )
+                render: (line) =>(<EditMenu onEditClick={() => {onEditLine(category.id, line)}} 
+                    onDeleteClick={() => {onDeleteLine(line)}}
+                    onDeleteMessage="Voulez-vous vraiment supprimer la ligne?"/> )
             },
             {
                 title: "",

--- a/frontend/src/components/edit-menu/EditMenu.jsx
+++ b/frontend/src/components/edit-menu/EditMenu.jsx
@@ -1,15 +1,17 @@
-import React, { Fragment, useState } from "react";
+import React, { Fragment } from "react";
 
-import { Popover, Button } from "antd";
+import { Popover, Button, Popconfirm } from "antd";
 
-import { SettingOutlined, DeleteOutlined, PlusOutlined, EditOutlined } from '@ant-design/icons';
+import { SettingOutlined, DeleteOutlined, EditOutlined } from '@ant-design/icons';
 
-const EditMenu = ({onEditClick, onDeleteClick}) => {
+const EditMenu = ({onEditClick, onDeleteClick, onDeleteMessage}) => {
 
     const popoverContent = (
         <Fragment>
             <Button icon={<EditOutlined/>} onClick={onEditClick}/>
-            <Button icon={<DeleteOutlined/>} onClick={onDeleteClick}/>
+            <Popconfirm title={onDeleteMessage} okText="Oui" cancelText="Non" onConfirm={onDeleteClick}>
+                <Button icon={<DeleteOutlined/>}/>
+            </Popconfirm>
         </Fragment>
     );
 

--- a/frontend/src/entries/Entries.jsx
+++ b/frontend/src/entries/Entries.jsx
@@ -72,7 +72,10 @@ const Entries = () => {
     const columns = [
         {
             title: "",
-            render: (entry) => <EditMenu key={entry.id} onEditClick={() => onCreateOrEditEntry(entry.id)} onDeleteClick={() => onDeleteEntry(entry)} />
+            render: (entry) => <EditMenu key={entry.id} 
+                onEditClick={() => onCreateOrEditEntry(entry.id)} 
+                onDeleteClick={() => onDeleteEntry(entry)} 
+                onDeleteMessage="Voulez-vous vraiment supprimer l'entrée?"/>
         },
         {
             title: "# Facture",

--- a/frontend/src/members/Members.jsx
+++ b/frontend/src/members/Members.jsx
@@ -74,7 +74,10 @@ const Members = () => {
         {
             title: "",
             width: 50,
-            render: (member) => <EditMenu key={member.id} onEditClick={() => onEditMember(member)} onDeleteClick={() => onDeleteMember(member)} />
+            render: (member) => <EditMenu key={member.id} 
+                onEditClick={() => onEditMember(member)} 
+                onDeleteClick={() => onDeleteMember(member)} 
+                onDeleteMessage="Voulez-vous vraiment supprimer ce membre?"/>
         },
         {
             title: "Nom",


### PR DESCRIPTION
### Explication

*Explication rapide*
Ajoute un popup de confirmation pour supprimer un objet (catégorie/ligne/entrée/membre)

### Checklist 
- [ ] Cette PR modifie la DB 
- [x] J'ai testé mes changements

### À tester

- Le popup de confirmation apparaît quand on clique le bouton de suppression sur les pages Lignes et catégories, Entrées budgétaires et Membres.
- La suppression n'est effectuée que si on clique Oui.

### Screenshot

![image](https://user-images.githubusercontent.com/25589681/99338384-146c4000-2852-11eb-84fa-6fb4563b768b.png)
