### PR TITLE
Fix migrations

### DIFF
--- a/migrations/00000000000001-user-init.js
+++ b/migrations/00000000000001-user-init.js
@@ -2,52 +2,7 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    return Promise.all([
-      queryInterface.createTable(
-        'Users',
-        {
-          id: {
-              type: Sequelize.UUID,
-              defaultValue: Sequelize.UUIDV4,
-              primaryKey: true
-          },
-          username: {
-              type: Sequelize.STRING,
-              allowNull: false,
-              unique: true
-          },
-          password: {
-              type: Sequelize.STRING,
-              allowNull: false
-          },
-          attemptFailed : {
-              type: Sequelize.INTEGER,
-              defaultValue: 0
-          },
-          isBlocked : {
-              type: Sequelize.BOOLEAN,
-              defaultValue: false
-          },
-          isAdmin : {
-              type: Sequelize.BOOLEAN,
-              defaultValue: false
-          },
-          activeBudgetId : {
-              type: Sequelize.UUID,
-              allowNull: true,
-              references: {
-                  model: 'Budgets',
-                  key: 'id'
-              },
-              onDelete: 'RESTRICT'
-          }
-        },
-        {
-          engine: 'MYISAM',                     // default: 'InnoDB'
-          charset: 'latin1'                     // default: null
-        }
-      ),
-    ]);
+    return queryInterface.sequelize.query("CREATE TABLE IF NOT EXISTS `Users` (`id` CHAR(36) BINARY , `username` VARCHAR(255) NOT NULL UNIQUE, `password` VARCHAR(255) NOT NULL, `attemptFailed` INTEGER DEFAULT 0, `isBlocked` TINYINT(1) DEFAULT false, `isAdmin` TINYINT(1) DEFAULT false, `activeBudgetId` CHAR(36) BINARY, PRIMARY KEY (`id`)) ENGINE=InnoDB;")
   },
 
   down: async (queryInterface, Sequelize) => {

--- a/migrations/00000000000002-budget-init.js
+++ b/migrations/00000000000002-budget-init.js
@@ -2,52 +2,9 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    return Promise.all([
-      queryInterface.createTable(
-        'Budgets',
-        {
-          id: {
-            type: Sequelize.UUID,
-            defaultValue: Sequelize.UUIDV4,
-            primaryKey: true
-          },
-          name: {
-              type: Sequelize.STRING,
-              unique: true,
-              allowNull: false,
-              unique: 'compositeUnique'
-          },
-          userId: {
-              type: Sequelize.UUID,
-              allowNull: false,
-              unique: 'compositeUnique',
-              references: {
-                  model: 'Users',
-                  key: 'id'
-              },
-              onDelete: 'RESTRICT'
-          },
-          startDate: {
-              type: Sequelize.DATE,
-              allowNull: false
-          },
-          endDate: {
-              type: Sequelize.DATE,
-              allowNull: false
-          },
-          isActive: {
-              type: Sequelize.BOOLEAN,
-              defaultValue: false
-          }
-        },
-        {
-          engine: 'MYISAM',                     // default: 'InnoDB'
-          charset: 'latin1'                     // default: null
-        }
-      ),
-    ]);
+    return queryInterface.sequelize.query("CREATE TABLE IF NOT EXISTS `Budgets` (`id` CHAR(36) BINARY , `name` VARCHAR(255) NOT NULL, `userId` CHAR(36) BINARY NOT NULL, `startDate` DATETIME NOT NULL, `endDate` DATETIME NOT NULL, `isActive` TINYINT(1) DEFAULT false, UNIQUE `compositeUnique` (`name`, `userId`), PRIMARY KEY (`id`), FOREIGN KEY (`userId`) REFERENCES `Users` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE) ENGINE=InnoDB;");
   },
-
+  
   down: async (queryInterface, Sequelize) => {
     queryInterface.dropTable('Budgets')
   }

--- a/migrations/00000000000003-category-init.js
+++ b/migrations/00000000000003-category-init.js
@@ -2,50 +2,7 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    return Promise.all([
-      queryInterface.createTable(
-        'Categories',
-        {
-          id: {
-            type: Sequelize.UUID,
-            defaultValue: Sequelize.UUIDV4,
-            primaryKey: true
-          },
-          name: {
-              type: Sequelize.STRING,
-              allowNull: false,
-              unique: 'compositeUnique'
-          },
-          orderNumber: {
-              type: Sequelize.INTEGER,
-              allowNull: false,
-              defaultValue: '99'
-          },
-          budgetId: {
-              type: Sequelize.UUID,
-              allowNull: false,
-              unique: 'compositeUnique',
-              references: {
-                  model: 'Budgets',
-                  key: 'id'
-              },
-              onDelete: 'RESTRICT'
-          },
-          type: {
-              type: Sequelize.ENUM('revenue', 'expense'),
-              allowNull: false,
-              unique: 'compositeUnique',
-              validate: {
-                  isIn: [['revenue', 'expense']]
-              }
-          }
-        },
-        {
-          engine: 'MYISAM',                     // default: 'InnoDB'
-          charset: 'latin1'                     // default: null
-        }
-      ),
-    ]);
+    return queryInterface.sequelize.query("CREATE TABLE IF NOT EXISTS `Categories` (`id` CHAR(36) BINARY , `name` VARCHAR(255) NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT '99', `budgetId` CHAR(36) BINARY NOT NULL, `type` ENUM('revenue', 'expense') NOT NULL, UNIQUE `compositeUnique` (`name`, `budgetId`, `type`), PRIMARY KEY (`id`), FOREIGN KEY (`budgetId`) REFERENCES `Budgets` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE) ENGINE=InnoDB;");
   },
 
   down: async (queryInterface, Sequelize) => {

--- a/migrations/20201126193150-line-init.js
+++ b/migrations/20201126193150-line-init.js
@@ -2,49 +2,7 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    return Promise.all([
-      queryInterface.createTable(
-        'Lines',
-        {
-          id: {
-            type: Sequelize.UUID,
-            defaultValue: Sequelize.UUIDV4,
-            primaryKey: true
-          },
-          name: {
-              type: Sequelize.STRING,
-              unique: 'compositeUnique'
-          },
-          description: {
-              type: Sequelize.STRING
-          },
-          orderNumber: {
-              type: Sequelize.INTEGER,
-              allowNull: false,
-              defaultValue: '99'
-          },
-          categoryId: {
-              type: Sequelize.UUID,
-              allowNull: false,
-              unique: 'compositeUnique',
-              references: {
-                  model: 'Categories',
-                  key: 'id'
-              },
-              onDelete: 'RESTRICT'
-          },
-          estimate: {
-              type: Sequelize.DECIMAL(10,2),
-              allowNull: false,
-              defaultValue: '0.00',
-          }
-        },
-        {
-          engine: 'MYISAM',                     // default: 'InnoDB'
-          charset: 'latin1'                     // default: null
-        }
-      ),
-    ]);
+    return queryInterface.sequelize.query("CREATE TABLE IF NOT EXISTS `Lines` (`id` CHAR(36) BINARY , `name` VARCHAR(255), `description` VARCHAR(255), `orderNumber` INTEGER NOT NULL DEFAULT '99', `categoryId` CHAR(36) BINARY NOT NULL, `estimate` DECIMAL(10,2) NOT NULL DEFAULT '0.00', UNIQUE `compositeUnique` (`name`, `categoryId`), PRIMARY KEY (`id`), FOREIGN KEY (`categoryId`) REFERENCES `Categories` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE) ENGINE=InnoDB;");
   },
 
   down: async (queryInterface, Sequelize) => {

--- a/migrations/20201126193647-entrystatus-init.js
+++ b/migrations/20201126193647-entrystatus-init.js
@@ -2,28 +2,7 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    return Promise.all([
-      queryInterface.createTable(
-        'EntryStatuses',
-        {
-          id: {
-            type: Sequelize.UUID,
-            defaultValue: Sequelize.UUIDV4,
-            primaryKey: true
-          },
-          name: {
-              type: Sequelize.STRING
-          },
-          position: {
-              type: Sequelize.INTEGER
-          }
-        },
-        {
-          engine: 'MYISAM',                     // default: 'InnoDB'
-          charset: 'latin1'                     // default: null
-        }
-      ),
-    ]);
+    return queryInterface.sequelize.query("CREATE TABLE IF NOT EXISTS `EntryStatuses` (`id` CHAR(36) BINARY , `name` VARCHAR(255), `position` INTEGER, PRIMARY KEY (`id`)) ENGINE=InnoDB;");
   },
 
   down: async (queryInterface, Sequelize) => {

--- a/migrations/20201126194026-members-init.js
+++ b/migrations/20201126194026-members-init.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    return queryInterface.sequelize.query("CREATE TABLE IF NOT EXISTS `Members` (`id` CHAR(36) BINARY , `name` VARCHAR(255) NOT NULL, `code` VARCHAR(255) NOT NULL UNIQUE, `email` VARCHAR(255) NOT NULL, `userId` CHAR(36) BINARY NOT NULL, PRIMARY KEY (`id`), FOREIGN KEY (`userId`) REFERENCES `Users` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE) ENGINE=InnoDB;");
+    return queryInterface.sequelize.query("CREATE TABLE IF NOT EXISTS `Members` (`id` CHAR(36) BINARY , `name` VARCHAR(255) NOT NULL, `code` VARCHAR(255) NOT NULL UNIQUE, `email` VARCHAR(255), `sms` VARCHAR(255), `notify` TINYINT(1) DEFAULT false, `active` TINYINT(1) DEFAULT true, `userId` CHAR(36) BINARY NOT NULL, `deleted` TINYINT(1) DEFAULT false, PRIMARY KEY (`id`), FOREIGN KEY (`userId`) REFERENCES `Users` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE) ENGINE=InnoDB;");
   },
 
   down: async (queryInterface, Sequelize) => {

--- a/migrations/20201126194026-members-init.js
+++ b/migrations/20201126194026-members-init.js
@@ -2,61 +2,7 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    return Promise.all([
-      queryInterface.createTable(
-        'Members',
-        {
-          id: {
-            type: Sequelize.UUID,
-            defaultValue: Sequelize.UUIDV4,
-            primaryKey: true
-          },
-          name: {
-              type: Sequelize.STRING,
-              allowNull: false
-          },
-          code: {
-              type: Sequelize.STRING,
-              allowNull: false,
-              unique: true
-          },
-          email: {
-              type: Sequelize.STRING,
-              allowNull: true
-          },
-          sms: {
-              type: Sequelize.STRING,
-              allowNull: true
-          },
-          notify : {
-              type: Sequelize.BOOLEAN,
-              defaultValue: false
-          },
-          active : {
-              type: Sequelize.BOOLEAN,
-              defaultValue: true
-          },
-          userId: {
-              type: Sequelize.UUID,
-              allowNull: false,
-              references: {
-                  model: 'Users',
-                  key: 'id'
-              },
-              onDelete: 'RESTRICT'
-          },
-          deleted : {
-              type: Sequelize.BOOLEAN,
-              allowNull: true,
-              defaultValue: false
-          },
-        },
-        {
-          engine: 'MYISAM',                     // default: 'InnoDB'
-          charset: 'latin1'                     // default: null
-        }
-      ),
-    ]);
+    return queryInterface.sequelize.query("CREATE TABLE IF NOT EXISTS `Members` (`id` CHAR(36) BINARY , `name` VARCHAR(255) NOT NULL, `code` VARCHAR(255) NOT NULL UNIQUE, `email` VARCHAR(255) NOT NULL, `userId` CHAR(36) BINARY NOT NULL, PRIMARY KEY (`id`), FOREIGN KEY (`userId`) REFERENCES `Users` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE) ENGINE=InnoDB;");
   },
 
   down: async (queryInterface, Sequelize) => {

--- a/migrations/20201126194353-entries-init.js
+++ b/migrations/20201126194353-entries-init.js
@@ -2,62 +2,7 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    return Promise.all([
-      queryInterface.createTable(
-        'Entries',
-        {
-          id: {
-            type: Sequelize.UUID,
-            defaultValue: Sequelize.UUIDV4,
-            primaryKey: true
-          },
-          lineId: {
-              type: Sequelize.UUID,
-              allowNull: false,
-              references: {
-                  model: 'Lines',
-                  key: 'id'
-              }
-          },
-          entryStatusId: {
-              type: Sequelize.UUID,
-              allowNull: true,
-              references: {
-                  model: 'EntryStatuses',
-                  key: 'id'
-              },
-              onDelete: 'RESTRICT'
-          },
-          memberId: {
-              type: Sequelize.UUID,
-              allowNull: true,
-              references: {
-                  model: 'Members',
-                  key: 'id'
-              },
-              onDelete: 'RESTRICT'
-          },
-          amount: {
-              type: Sequelize.DECIMAL(10,2),
-              allowNull: false,
-              defaultValue: '0.00',
-          },
-          date: {
-              type: Sequelize.DATE,
-          },
-          description: {
-              type: Sequelize.STRING
-          },
-          receiptCode: {
-              type: Sequelize.STRING
-          }
-        },
-        {
-          engine: 'MYISAM',                     // default: 'InnoDB'
-          charset: 'latin1'                     // default: null
-        }
-      ),
-    ]);
+    return queryInterface.sequelize.query("CREATE TABLE IF NOT EXISTS `Entries` (`id` CHAR(36) BINARY , `lineId` CHAR(36) BINARY NOT NULL, `entryStatusId` CHAR(36) BINARY, `memberId` CHAR(36) BINARY, `amount` DECIMAL(10,2) NOT NULL DEFAULT '0.00', `date` DATETIME, `description` VARCHAR(255), `receiptCode` VARCHAR(255), PRIMARY KEY (`id`), FOREIGN KEY (`lineId`) REFERENCES `Lines` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE, FOREIGN KEY (`entryStatusId`) REFERENCES `EntryStatuses` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE, FOREIGN KEY (`memberId`) REFERENCES `Members` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE) ENGINE=InnoDB;");
   },
 
   down: async (queryInterface, Sequelize) => {

--- a/migrations/20201126195033-cashflows-init.js
+++ b/migrations/20201126195033-cashflows-init.js
@@ -2,47 +2,7 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    return Promise.all([
-      queryInterface.createTable(
-        'Cashflows',
-        {
-          id: {
-            type: Sequelize.UUID,
-            defaultValue: Sequelize.UUIDV4,
-            primaryKey: true
-          },
-          categoryId: {
-              type: Sequelize.UUID,
-              allowNull: false,
-              unique: 'compositeUnique',
-              references: {
-                  model: 'Categories',
-                  key: 'id'
-              },
-              onDelete: 'RESTRICT'
-          },
-          year: {
-              type: Sequelize.INTEGER(4),
-              allowNull: false,
-              unique: 'compositeUnique'
-          },
-          month: {
-              type: Sequelize.INTEGER(2),
-              allowNull: false,
-              unique: 'compositeUnique'
-          },
-          estimate: {
-              type: Sequelize.DECIMAL(10,2),
-              allowNull: false,
-              defaultValue: '0.00',
-          }
-        },
-        {
-          engine: 'MYISAM',                     // default: 'InnoDB'
-          charset: 'latin1'                     // default: null
-        }
-      ),
-    ]);
+    return queryInterface.sequelize.query("CREATE TABLE IF NOT EXISTS `Cashflows` (`id` CHAR(36) BINARY , `categoryId` CHAR(36) BINARY NOT NULL, `year` INTEGER(4) NOT NULL, `month` INTEGER(2) NOT NULL, `estimate` DECIMAL(10,2) NOT NULL DEFAULT '0.00', UNIQUE `compositeUnique` (`categoryId`, `year`, `month`), PRIMARY KEY (`id`), FOREIGN KEY (`categoryId`) REFERENCES `Categories` (`id`) ON DELETE NO ACTION ON UPDATE CASCADE) ENGINE=InnoDB;");
   },
 
   down: async (queryInterface, Sequelize) => {

--- a/migrations/20201126200419-access-init.js
+++ b/migrations/20201126200419-access-init.js
@@ -2,34 +2,7 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    return Promise.all([
-      queryInterface.createTable(
-        'Accesses',
-        {
-          budgetId: {
-            type: Sequelize.UUID,
-            allowNull: false,
-              references: {
-                model: 'Budgets',
-                key: 'id'
-              }
-          },
-          userId: {
-              type: Sequelize.UUID,
-              allowNull: false,
-              references: {
-                model: 'Users',
-                key: 'id'
-              },
-              onDelete: 'RESTRICT'
-          }
-        },
-        {
-          engine: 'MYISAM',                     // default: 'InnoDB'
-          charset: 'latin1'                     // default: null
-        }
-      ),
-    ]);
+    return queryInterface.sequelize.query("CREATE TABLE IF NOT EXISTS `Accesses` (`budgetId` CHAR(36) BINARY NOT NULL , `userId` CHAR(36) BINARY NOT NULL , UNIQUE `Accesses_userId_budgetId_unique` (`budgetId`, `userId`), PRIMARY KEY (`budgetId`, `userId`), FOREIGN KEY (`budgetId`) REFERENCES `Budgets` (`id`) ON DELETE CASCADE ON UPDATE CASCADE, FOREIGN KEY (`userId`) REFERENCES `Users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE) ENGINE=InnoDB;");
   },
 
   down: async (queryInterface, Sequelize) => {


### PR DESCRIPTION
### Explication

Les migrations avec createTable ne créent pas les contraintes automatiquement. Il faudrait idéalement utiliser des transactions et utiliser la fonction addConstraint pour les ajouter après la création d'une table. En attendant, les premières migrations utiliseront du raw SQL. 


### Checklist 
- [ ] Cette PR modifie la DB 
- [ ] J'ai testé mes changements

### À tester

Tous les tests passent avec ces migrations.

### Screenshot

*Si on a un changement au frontend*
